### PR TITLE
Fix bug where records were being updated to their existing IP address

### DIFF
--- a/src/cloudflare-dyndns/main.go
+++ b/src/cloudflare-dyndns/main.go
@@ -220,7 +220,7 @@ func main() {
                     }
                     log.Printf("updating %s...\n", record.Name)
 
-                    err := updateRecord(client, zone.ID, record.ID, record.Name, record.Type, record.Content)
+                    err := updateRecord(client, zone.ID, record.ID, record.Name, record.Type, newIP)
                     if err != nil {
                         panic(err)
                     }


### PR DESCRIPTION
The call to `updateRecord()` was being passed the IP that the record already contained, making the update request essentially a no-op. Let's send the new IP address instead. 

PS: Thank you for this tool, it's fantastic! :smile: 
