### PR TITLE
Switch key to apikey in Makefile so 'make run' properly works

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ build:
 
 run: build
 	./bin/cloudflare-dyndns \
-		-key "" \
+		-apikey "" \
 		-email "cole.mickens@gmail.com" \
 		-records "*.mickens.xxx,mickens.xxx,*.mickens.io,mickens.io,recessionomics.us,www.recessionomics.us,*.mickens.me,mickens.me,*.mickens.tv,mickens.tv,*.mickens.us,mickens.us,cole.mickens.us"
 


### PR DESCRIPTION
This fixes an error when using `make run` 

"flag provided but not defined -key"

Nice project too! Exactly what I was looking for. :+1: 
